### PR TITLE
Dropped Nette 2.3 and PHP under 5.6 support, added PHP support up to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ sudo: false
 
 env:
   - NETTE=default
-  - NETTE=~2.3.0
-  - NETTE=~2.3.0 PREFER_LOWEST=true
   - NETTE=~2.4.0
   - NETTE=~2.4.0 PREFER_LOWEST=true
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
 		}
 	},
 	"require": {
-		"php": "~5.5|~7.0",
-		"nette/di": "~2.3,<2.5.0",
-		"nette/application": "~2.3,<2.5.0",
-		"vrtak-cz/newrelic-tracy": "~6.0.0"
+		"php": ">=5.6",
+		"nette/di": "~2.4",
+		"nette/application": "~2.4",
+		"vrtak-cz/newrelic-tracy": "^7.0"
 	},
 	"require-dev": {
 		"jakub-onderka/php-console-highlighter": "0.3.2",

--- a/src/Callbacks/OnErrorCallback.php
+++ b/src/Callbacks/OnErrorCallback.php
@@ -4,7 +4,7 @@ namespace VrtakCZ\NewRelic\Nette\Callbacks;
 
 use Nette\Application\Application;
 
-class OnErrorCallback extends \Nette\Object
+class OnErrorCallback
 {
 
 	/**

--- a/src/Callbacks/OnRequestCallback.php
+++ b/src/Callbacks/OnRequestCallback.php
@@ -7,7 +7,7 @@ use Nette\Application\Request;
 use Nette\Application\UI\Presenter;
 use Nette\Utils\Strings;
 
-class OnRequestCallback extends \Nette\Object
+class OnRequestCallback
 {
 
 	/** @var array */

--- a/src/RUM/User.php
+++ b/src/RUM/User.php
@@ -2,7 +2,7 @@
 
 namespace VrtakCZ\NewRelic\Nette\RUM;
 
-class User extends \Nette\Object
+class User
 {
 
 	/** @var bool */


### PR DESCRIPTION
I believe it's time. Also needed to get rid of `Nette\Object` deprecation errors.

Look also at https://github.com/Vrtak-CZ/NewRelic-Tracy/pull/3